### PR TITLE
Refine responsive layout and streamline CTAs

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,15 @@
+Custom License for GOOD FINE DINING Landing Page
+
+Copyright (c) 2024 Simone Cascioli. All rights reserved.
+
+Permission is hereby granted to Simone Cascioli and the Good Fine Dining brand ("the Client") to use, reproduce, display, and modify
+this work for business purposes related to the Client.
+
+Any redistribution, sublicensing, sale, or other commercial use by third parties is prohibited without prior written consent from Simone Cascioli.
+
+The original author retains the right to display this work, in whole or in part, for self-promotional purposes, including public portfolios and case studies,
+provided that such display does not imply endorsement by the Client.
+
+THE WORK IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR
+ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE WORK OR THE USE OR OTHER DEALINGS IN THE WORK.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,49 @@
-# good-fine-dining
+# GOOD FINE DINING – Landing Page
+
+Landing page statica ispirata al sito good.simonecascioli.it, sviluppata con HTML5 e CSS3 per massimizzare performance, accessibilità e ottimizzazione SEO.
+
+## Contenuti
+
+Tutti i testi sono forniti dal cliente e riportati integralmente come da specifiche.
+
+## Requisiti
+
+- Qualsiasi browser moderno.
+- (Opzionale) Un server statico locale per testare la pagina.
+
+## Avvio del progetto
+
+1. Clona il repository e posizionati nella cartella del progetto.
+2. Avvia un server statico, ad esempio con [serve](https://www.npmjs.com/package/serve):
+   ```bash
+   npx serve .
+   ```
+   In alternativa, puoi semplicemente aprire `index.html` direttamente nel browser.
+3. Visita l'URL indicato nel terminale (ad esempio `http://localhost:3000`) per visualizzare la landing page.
+
+## Struttura del progetto
+
+```
+.
+├── index.html      # Struttura del markup e metadati SEO
+├── styles.css      # Stili globali e responsive design
+├── LICENSE         # Licenza del progetto
+└── README.md       # Documentazione e istruzioni
+```
+
+## Tecnologie utilizzate
+
+- HTML5 semantico
+- CSS3 moderno (flexbox, grid, tipografia responsive)
+- Google Fonts (Playfair Display, Work Sans)
+
+## Personalizzazione
+
+Gli stili possono essere adattati modificando le variabili CSS definite in `:root`. Le immagini di background possono essere aggiornate intervenendo sulle proprietà `background` delle relative sezioni.
+
+## SEO e Performance
+
+- Markup semantico con intestazioni gerarchiche corrette.
+- Meta description ottimizzata.
+- Fonts caricati in modo ottimizzato con `preconnect`.
+- Layout responsive con attenzione all'accessibilità del contrasto.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,301 @@
+<!DOCTYPE html>
+<html lang="it">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta
+      name="description"
+      content="GOOD FINE DINING - Atmosfera rilassante, ingredienti esclusivi, vasta selezione di vini, ospitalità e passione."
+    />
+    <title>GOOD FINE DINING</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;600;700&family=Work+Sans:wght@300;400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header class="site-header">
+      <div class="site-header__inner">
+        <a class="site-header__brand" href="#top">GOOD FINE DINING</a>
+        <button class="site-header__toggle" type="button" aria-expanded="false" aria-controls="site-nav">
+          <span class="sr-only">Apri il menu</span>
+          <span class="site-header__toggle-line" aria-hidden="true"></span>
+          <span class="site-header__toggle-line" aria-hidden="true"></span>
+          <span class="site-header__toggle-line" aria-hidden="true"></span>
+        </button>
+        <nav class="site-nav" id="site-nav" aria-label="Navigazione principale" data-state="closed">
+          <a href="#cucina">LA NOSTRA CUCINA</a>
+          <a href="#ingredienti">INGREDIENTI SELEZIONATI</a>
+          <a href="#cantina">LA CANTINA</a>
+          <a href="#proposte">LE NOSTRE PROPOSTE</a>
+          <a class="site-nav__cta" href="tel:+390881123456">Prenota ora</a>
+        </nav>
+      </div>
+    </header>
+
+    <main id="top">
+      <section class="hero" data-animate>
+        <div class="hero__overlay" aria-hidden="true"></div>
+        <div class="hero__inner">
+          <div class="hero__content" data-animate style="--delay: 0.05s">
+            <p class="hero__eyebrow">GOOD FINE DINING</p>
+            <h1>Atmosfera rilassante, ingredienti esclusivi, vasta selezione di vini, ospitalità e passione</h1>
+            <div class="hero__buttons">
+              <a class="button button--accent" href="tel:+390881123456">Prenota telefonicamente</a>
+              <a class="button button--surface" href="https://wa.me/390881123456" target="_blank" rel="noreferrer noopener">
+                Scrivici su WhatsApp
+              </a>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="section section--intro" id="cucina">
+        <div class="section__inner">
+          <div class="split" data-animate>
+            <div class="split__content">
+              <h2>LA NOSTRA CUCINA</h2>
+              <p>Tradizione ed innovazione si incontrano in ogni piatto, creando momenti di qualità ed autentica convivialità.</p>
+            </div>
+            <figure class="split__media">
+              <img
+                src="https://images.unsplash.com/photo-1504753793650-d4a2b783c15e?auto=format&fit=crop&w=1200&q=80"
+                alt="Chef al lavoro in cucina"
+              />
+            </figure>
+          </div>
+        </div>
+      </section>
+
+      <section class="section section--ingredients" id="ingredienti">
+        <div class="section__inner">
+          <div class="split split--reverse" data-animate style="--delay: 0.08s">
+            <div class="split__content">
+              <h2>INGREDIENTI SELEZIONATI</h2>
+              <p>Scegliamo con cura le migliori materie prime ed i prodotti di qualità per ogni piatto.</p>
+            </div>
+            <figure class="split__media">
+              <img
+                src="https://images.unsplash.com/photo-1499636136210-6f4ee915583e?auto=format&fit=crop&w=1200&q=80"
+                alt="Ingredienti freschi su un tavolo"
+              />
+            </figure>
+          </div>
+        </div>
+      </section>
+
+      <section class="section section--experience" id="cantina">
+        <div class="section__inner">
+          <div class="experience">
+            <article class="experience__item" data-animate>
+              <div class="experience__content">
+                <h2>LA CUCINA</h2>
+                <p>Interpretata con grande qualità e creatività.</p>
+              </div>
+              <figure class="experience__media">
+                <img
+                  src="https://images.unsplash.com/photo-1517248135467-4c7edcad34c4?auto=format&fit=crop&w=1200&q=80"
+                  alt="Dettaglio di un piatto gourmet"
+                />
+              </figure>
+            </article>
+            <article class="experience__item experience__item--reverse" data-animate style="--delay: 0.08s">
+              <div class="experience__content">
+                <h2>LA CANTINA</h2>
+                <p>Curata e selezionata per accompagnare al meglio ogni piatto</p>
+              </div>
+              <figure class="experience__media">
+                <img
+                  src="https://images.unsplash.com/photo-1510626176961-4b57d4fbad03?auto=format&fit=crop&w=1200&q=80"
+                  alt="Bottiglie di vino in cantina"
+                />
+              </figure>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section class="section section--proposte" id="proposte">
+        <div class="section__inner">
+          <header class="section__header" data-animate>
+            <h2>LE NOSTRE PROPOSTE</h2>
+            <p>Dalla cena di tutti i giorni alle occasioni speciali, ogni momento ha la sua proposta ideale.</p>
+          </header>
+          <div class="cards">
+            <article class="card" data-animate style="--delay: 0.05s">
+              <h3>MENU À LA CARTE</h3>
+              <p>Possibilità di scegliere tra una selezione di piatti gustosi ed armoniosi.</p>
+            </article>
+            <article class="card" data-animate style="--delay: 0.1s">
+              <h3>MENU DEGUSTAZIONE</h3>
+              <p>Occasione per organizzare un percorso con abbinamenti cibo/vino che rappresenta la nostra filosofia di ristorazione.</p>
+            </article>
+            <article class="card" data-animate style="--delay: 0.15s">
+              <h3>EVENTI PRIVATI</h3>
+              <p>Menù personalizzati per celebrare le occasioni speciali, con menù dedicati alle vostre esigenze</p>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section class="section section--cta" id="contatti">
+        <div class="section__inner">
+          <div class="cta" data-animate>
+            <div class="cta__content">
+              <h2>HAI ESIGENZE PARTICOLARI?</h2>
+              <p>Contattaci per creare un'esperienza su misura per te e i tuoi ospiti. Saremo felici di organizzare il tuo evento perfetto.</p>
+            </div>
+            <div class="cta__note">
+              <p>Vieni a trovarci.</p>
+              <p>Ti aspettiamo per condividere insieme la passione per la buona cucina.</p>
+            </div>
+            <div class="cta__actions">
+              <a class="button button--accent" href="tel:+390881123456">Chiama ora</a>
+              <a class="button button--surface" href="https://wa.me/390881123456" target="_blank" rel="noreferrer noopener">
+                Scrivici su WhatsApp
+              </a>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="footer">
+      <div class="footer__inner">
+        <div class="footer__brand" data-animate>
+          <p class="footer__brand-name">GOOD FINE DINING</p>
+        </div>
+        <div class="footer__grid">
+          <div class="footer__group" data-animate style="--delay: 0.05s">
+            <h3>Contatti</h3>
+            <ul>
+              <li><a href="tel:+390881123456">+39 0881 123456</a></li>
+              <li><a href="mailto:info@goodfoggia.it">info@goodfoggia.it</a></li>
+            </ul>
+          </div>
+          <div class="footer__group" data-animate style="--delay: 0.08s">
+            <h3>Indirizzo</h3>
+            <address>
+              Via Example, 123<br />
+              71121 Foggia (FG)
+            </address>
+            <a class="footer__directions" href="https://www.google.com/maps?q=Via+Example,+123,+71121+Foggia" target="_blank" rel="noreferrer noopener">
+              Ottieni indicazioni
+            </a>
+          </div>
+          <div class="footer__group" data-animate style="--delay: 0.11s">
+            <h3>Orari di apertura</h3>
+            <ul class="footer__hours">
+              <li><span>Martedì - Giovedì</span><span>19:30 - 00:00</span></li>
+              <li><span>Venerdì - Sabato</span><span>19:30 - 01:00</span></li>
+              <li><span>Domenica</span><span>19:30 - 00:00</span></li>
+              <li><span>Lunedì</span><span>Chiuso</span></li>
+            </ul>
+          </div>
+        </div>
+        <p class="footer__note">© GOOD FINE DINING. Tutti i diritti riservati.</p>
+      </div>
+    </footer>
+
+    <script>
+      (function () {
+        const header = document.querySelector('.site-header');
+        const nav = document.querySelector('#site-nav');
+        const toggle = document.querySelector('.site-header__toggle');
+        const toggleLabel = toggle?.querySelector('.sr-only');
+        const smoothLinks = document.querySelectorAll('a[href^="#"]');
+
+        const closeNav = () => {
+          if (!nav) return;
+          nav.dataset.state = 'closed';
+          if (toggle) {
+            toggle.setAttribute('aria-expanded', 'false');
+          }
+          if (toggleLabel) {
+            toggleLabel.textContent = 'Apri il menu';
+          }
+          document.body.classList.remove('nav-open');
+        };
+
+        const openNav = () => {
+          if (!nav) return;
+          nav.dataset.state = 'open';
+          if (toggle) {
+            toggle.setAttribute('aria-expanded', 'true');
+          }
+          if (toggleLabel) {
+            toggleLabel.textContent = 'Chiudi il menu';
+          }
+          document.body.classList.add('nav-open');
+        };
+
+        toggle?.addEventListener('click', () => {
+          if (!nav) return;
+          const isOpen = nav.dataset.state === 'open';
+          if (isOpen) {
+            closeNav();
+          } else {
+            openNav();
+          }
+        });
+
+        window.addEventListener('resize', () => {
+          if (window.innerWidth >= 768) {
+            closeNav();
+          }
+        });
+
+        document.addEventListener('click', (event) => {
+          if (!nav || nav.dataset.state !== 'open') return;
+          if (toggle?.contains(event.target) || nav.contains(event.target)) {
+            return;
+          }
+          closeNav();
+        });
+
+        document.addEventListener('keydown', (event) => {
+          if (event.key !== 'Escape') {
+            return;
+          }
+          if (!nav || nav.dataset.state !== 'open') {
+            return;
+          }
+          closeNav();
+          toggle?.focus();
+        });
+
+        const scrollToTarget = (target) => {
+          const targetTop = target.getBoundingClientRect().top + window.pageYOffset;
+          window.requestAnimationFrame(() => {
+            const offset = header ? header.offsetHeight : 0;
+            window.scrollTo({
+              top: targetTop - offset + 8,
+              behavior: 'smooth',
+            });
+          });
+        };
+
+        smoothLinks.forEach((link) => {
+          link.addEventListener('click', (event) => {
+            const hash = link.getAttribute('href');
+            if (!hash || hash === '#' || hash.startsWith('#!')) {
+              return;
+            }
+
+            const target = document.querySelector(hash);
+            if (!target) {
+              return;
+            }
+
+            event.preventDefault();
+            closeNav();
+            scrollToTarget(target);
+          });
+        });
+      })();
+    </script>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -207,6 +207,7 @@
         const toggle = document.querySelector('.site-header__toggle');
         const toggleLabel = toggle?.querySelector('.sr-only');
         const smoothLinks = document.querySelectorAll('a[href^="#"]');
+        const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
 
         const closeNav = () => {
           if (!nav) return;
@@ -268,14 +269,39 @@
         });
 
         const scrollToTarget = (target) => {
-          const targetTop = target.getBoundingClientRect().top + window.pageYOffset;
-          window.requestAnimationFrame(() => {
-            const offset = header ? header.offsetHeight : 0;
-            window.scrollTo({
-              top: targetTop - offset + 8,
-              behavior: 'smooth',
-            });
-          });
+          const offset = header ? header.offsetHeight : 0;
+          const destination = target.getBoundingClientRect().top + window.pageYOffset - offset + 8;
+
+          if (prefersReducedMotion.matches) {
+            window.scrollTo(0, destination);
+            return;
+          }
+
+          const start = window.pageYOffset;
+          const distance = destination - start;
+          const duration = 720;
+          let startTime = null;
+
+          const easeInOutCubic = (time) =>
+            time < 0.5 ? 4 * time * time * time : 1 - Math.pow(-2 * time + 2, 3) / 2;
+
+          const animateScroll = (currentTime) => {
+            if (startTime === null) {
+              startTime = currentTime;
+            }
+
+            const elapsed = currentTime - startTime;
+            const progress = Math.min(elapsed / duration, 1);
+            const easedProgress = easeInOutCubic(progress);
+
+            window.scrollTo(0, start + distance * easedProgress);
+
+            if (elapsed < duration) {
+              window.requestAnimationFrame(animateScroll);
+            }
+          };
+
+          window.requestAnimationFrame(animateScroll);
         };
 
         smoothLinks.forEach((link) => {

--- a/styles.css
+++ b/styles.css
@@ -123,6 +123,7 @@ main {
 .site-header__toggle {
   display: inline-flex;
   flex-direction: column;
+  align-items: center;
   justify-content: center;
   gap: 0.35rem;
   padding: 0.35rem;

--- a/styles.css
+++ b/styles.css
@@ -17,6 +17,10 @@
   --header-height: 4.75rem;
 }
 
+html {
+  scroll-padding-top: calc(var(--header-height) + 8px);
+}
+
 * {
   box-sizing: border-box;
 }
@@ -58,10 +62,6 @@ button {
   border: none;
   background: none;
   cursor: pointer;
-}
-
-main {
-  padding-top: var(--header-height);
 }
 
 .sr-only {

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,687 @@
+:root {
+  color-scheme: light;
+  --font-display: 'Playfair Display', 'Times New Roman', serif;
+  --font-sans: 'Work Sans', 'Helvetica Neue', Arial, sans-serif;
+  --color-bg: #f6f1ea;
+  --color-text: #24170f;
+  --color-muted: rgba(36, 23, 15, 0.68);
+  --color-accent: #b88a54;
+  --color-accent-strong: #c9a06c;
+  --color-surface: rgba(255, 255, 255, 0.78);
+  --color-surface-strong: #fffdf8;
+  --shadow-soft: 0 22px 60px rgba(36, 23, 15, 0.14);
+  --shadow-strong: 0 32px 80px rgba(36, 23, 15, 0.22);
+  --radius-lg: 26px;
+  --radius-md: 18px;
+  --max-width: 1180px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: var(--font-sans);
+  background-color: var(--color-bg);
+  color: var(--color-text);
+  line-height: 1.65;
+  -webkit-font-smoothing: antialiased;
+}
+
+body.nav-open {
+  overflow: hidden;
+}
+
+img {
+  display: block;
+  max-width: 100%;
+  height: auto;
+  border-radius: var(--radius-lg);
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:focus-visible,
+button:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 4px;
+}
+
+button {
+  font: inherit;
+  color: inherit;
+  border: none;
+  background: none;
+  cursor: pointer;
+}
+
+main {
+  padding-top: 4.75rem;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+[data-animate] {
+  opacity: 0;
+  transform: translateY(36px);
+  animation: fade-up var(--duration, 900ms) cubic-bezier(0.22, 0.61, 0.36, 1) var(--delay, 0s) forwards;
+}
+
+@keyframes fade-up {
+  from {
+    opacity: 0;
+    transform: translateY(36px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  width: 100%;
+  padding: 0.9rem 1.25rem;
+  background: linear-gradient(180deg, rgba(246, 241, 234, 0.94), rgba(246, 241, 234, 0.75));
+  backdrop-filter: blur(12px);
+  border-bottom: 1px solid rgba(36, 23, 15, 0.06);
+}
+
+.site-header__inner {
+  margin: 0 auto;
+  width: min(100%, var(--max-width));
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.site-header__brand {
+  font-family: var(--font-display);
+  font-weight: 600;
+  letter-spacing: 0.32em;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+}
+
+.site-header__toggle {
+  display: inline-flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 0.35rem;
+  padding: 0.35rem;
+  border-radius: 999px;
+  width: 2.75rem;
+  height: 2.75rem;
+  background: rgba(36, 23, 15, 0.08);
+  transition: background 0.2s ease;
+}
+
+.site-header__toggle-line {
+  width: 1.4rem;
+  height: 2px;
+  border-radius: 999px;
+  background-color: var(--color-text);
+  transition: transform 0.2s ease, opacity 0.2s ease;
+}
+
+body.nav-open .site-header__toggle-line:nth-of-type(1) {
+  transform: translateY(6px) rotate(45deg);
+}
+
+body.nav-open .site-header__toggle-line:nth-of-type(2) {
+  opacity: 0;
+}
+
+body.nav-open .site-header__toggle-line:nth-of-type(3) {
+  transform: translateY(-6px) rotate(-45deg);
+}
+
+.site-nav {
+  position: absolute;
+  top: calc(100% + 0.75rem);
+  right: 1.25rem;
+  left: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1.5rem;
+  border-radius: var(--radius-md);
+  background: var(--color-surface-strong);
+  box-shadow: var(--shadow-soft);
+  transform-origin: top;
+  transform: scale(0.98);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.25s ease, transform 0.25s ease;
+}
+
+.site-nav[data-state='open'] {
+  opacity: 1;
+  transform: scale(1);
+  pointer-events: auto;
+}
+
+.site-nav a {
+  font-size: 0.85rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--color-muted);
+  transition: color 0.2s ease;
+}
+
+.site-nav a:hover,
+.site-nav a:focus-visible {
+  color: var(--color-text);
+}
+
+.site-nav__cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.55rem 1.25rem;
+  border-radius: 999px;
+  background: linear-gradient(120deg, var(--color-accent), var(--color-accent-strong));
+  color: #fffdf8;
+  box-shadow: var(--shadow-soft);
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.85rem 1.45rem;
+  border-radius: 999px;
+  font-size: 0.95rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+.button--accent {
+  background: linear-gradient(120deg, var(--color-accent), var(--color-accent-strong));
+  color: #fffdf8;
+  box-shadow: var(--shadow-soft);
+}
+
+.button--surface {
+  background: var(--color-surface);
+  color: var(--color-text);
+  border: 1px solid rgba(36, 23, 15, 0.12);
+}
+
+.button:hover,
+.button:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-strong);
+}
+
+.section {
+  padding: clamp(3.5rem, 8vw, 6rem) 1.25rem;
+}
+
+.section__inner {
+  margin: 0 auto;
+  width: min(100%, var(--max-width));
+  display: flex;
+  flex-direction: column;
+  gap: clamp(2.5rem, 5vw, 3.5rem);
+}
+
+.section__header {
+  display: grid;
+  gap: 1rem;
+  text-align: left;
+}
+
+.section__header h2 {
+  font-family: var(--font-display);
+  font-size: clamp(1.8rem, 4vw, 2.75rem);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  margin: 0;
+}
+
+.section__header p {
+  margin: 0;
+  color: var(--color-muted);
+  font-size: 1rem;
+}
+
+.hero {
+  position: relative;
+  padding: clamp(5.5rem, 14vw, 10rem) 1.25rem clamp(3.75rem, 10vw, 6rem);
+  display: flex;
+  justify-content: center;
+  color: #fffaf2;
+  overflow: hidden;
+  background: linear-gradient(135deg, rgba(36, 23, 15, 0.85), rgba(36, 23, 15, 0.54)),
+    url('https://images.unsplash.com/photo-1521017432531-fbd92d768814?auto=format&fit=crop&w=1600&q=80') center / cover no-repeat;
+}
+
+.hero__overlay {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(160deg, rgba(36, 23, 15, 0.82), rgba(36, 23, 15, 0.68));
+}
+
+.hero__inner {
+  position: relative;
+  z-index: 1;
+  width: min(100%, 1100px);
+  display: flex;
+  flex-direction: column;
+}
+
+.hero__content {
+  display: grid;
+  gap: 1.5rem;
+  max-width: 36rem;
+}
+
+.hero__eyebrow {
+  margin: 0;
+  font-size: 0.85rem;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: rgba(255, 250, 242, 0.75);
+}
+
+.hero h1 {
+  margin: 0;
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: clamp(2.1rem, 6vw, 3.6rem);
+  line-height: 1.15;
+}
+
+.hero__buttons {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.75rem;
+}
+
+.split {
+  display: grid;
+  gap: clamp(1.75rem, 4vw, 2.5rem);
+}
+
+.split__content h2 {
+  margin: 0 0 0.75rem;
+  font-family: var(--font-display);
+  font-size: clamp(1.8rem, 4vw, 2.75rem);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.split__content p {
+  margin: 0;
+  color: var(--color-muted);
+  font-size: 1rem;
+}
+
+.split__media {
+  margin: 0;
+}
+
+.section--ingredients {
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.35), rgba(255, 255, 255, 0));
+}
+
+.experience {
+  display: grid;
+  gap: clamp(2rem, 5vw, 3rem);
+}
+
+.experience__item {
+  display: grid;
+  gap: 1.5rem;
+  padding: clamp(1.75rem, 4vw, 2.5rem);
+  border-radius: var(--radius-lg);
+  background: var(--color-surface-strong);
+  box-shadow: var(--shadow-soft);
+}
+
+.experience__media {
+  margin: 0;
+}
+
+.experience__item--reverse {
+  background: linear-gradient(160deg, rgba(255, 255, 255, 0.95), rgba(246, 241, 234, 0.7));
+}
+
+.experience__content h2 {
+  margin: 0 0 0.75rem;
+  font-family: var(--font-display);
+  font-size: clamp(1.7rem, 3.5vw, 2.5rem);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.experience__content p {
+  margin: 0;
+  color: var(--color-muted);
+}
+
+.cards {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.card {
+  padding: clamp(1.75rem, 4vw, 2.5rem);
+  border-radius: var(--radius-lg);
+  background: var(--color-surface-strong);
+  box-shadow: var(--shadow-soft);
+  display: grid;
+  gap: 0.85rem;
+}
+
+.card h3 {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: clamp(1.5rem, 3vw, 2.1rem);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.card p {
+  margin: 0;
+  color: var(--color-muted);
+}
+
+.section--cta .cta {
+  display: grid;
+  gap: clamp(1.75rem, 4vw, 2.5rem);
+  padding: clamp(2rem, 5vw, 3rem);
+  border-radius: var(--radius-lg);
+  background: linear-gradient(145deg, rgba(36, 23, 15, 0.85), rgba(36, 23, 15, 0.72));
+  color: #fffaf2;
+  box-shadow: var(--shadow-strong);
+}
+
+.cta__content h2 {
+  margin: 0 0 0.85rem;
+  font-family: var(--font-display);
+  font-size: clamp(1.9rem, 4.5vw, 3rem);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.cta__content p {
+  margin: 0;
+  color: rgba(255, 250, 242, 0.85);
+}
+
+.cta__note {
+  display: grid;
+  gap: 0.25rem;
+  color: rgba(255, 250, 242, 0.78);
+  font-style: italic;
+}
+
+.cta__actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.footer {
+  padding: clamp(3rem, 6vw, 4.25rem) 1.25rem;
+  background: rgba(36, 23, 15, 0.92);
+  color: rgba(255, 250, 242, 0.9);
+}
+
+.footer__inner {
+  margin: 0 auto;
+  width: min(100%, var(--max-width));
+  display: grid;
+  gap: clamp(2rem, 5vw, 3rem);
+}
+
+.footer__brand-name {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: 1.1rem;
+  letter-spacing: 0.38em;
+  text-transform: uppercase;
+}
+
+.footer__grid {
+  display: grid;
+  gap: 1.75rem;
+}
+
+.footer__group h3 {
+  margin: 0 0 0.75rem;
+  font-size: 0.95rem;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: rgba(255, 250, 242, 0.8);
+}
+
+.footer__group ul,
+.footer__group address {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  font-style: normal;
+  color: rgba(255, 250, 242, 0.88);
+}
+
+.footer__group a {
+  color: inherit;
+  transition: color 0.2s ease;
+}
+
+.footer__group a:hover,
+.footer__group a:focus-visible {
+  color: #fffdf8;
+}
+
+.footer__directions {
+  display: inline-flex;
+  margin-top: 0.75rem;
+  font-size: 0.95rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.footer__hours {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.footer__hours li {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.footer__note {
+  margin: 0;
+  font-size: 0.85rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(255, 250, 242, 0.6);
+}
+
+@media (min-width: 640px) {
+  .site-header__brand {
+    font-size: 0.95rem;
+  }
+
+  .section__header,
+  .cta,
+  .cards,
+  .experience {
+    gap: 2rem;
+  }
+
+  .cards {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .cards > :last-child {
+    grid-column: span 2;
+  }
+
+  .footer__grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 768px) {
+  main {
+    padding-top: 5.5rem;
+  }
+
+  .site-header__toggle {
+    display: none;
+  }
+
+  .site-nav {
+    position: static;
+    flex-direction: row;
+    align-items: center;
+    gap: 1.5rem;
+    padding: 0;
+    background: transparent;
+    box-shadow: none;
+    transform: none;
+    opacity: 1;
+    pointer-events: auto;
+  }
+
+  .site-nav a {
+    font-size: 0.9rem;
+    padding-bottom: 0.2rem;
+    position: relative;
+  }
+
+  .site-nav a::after {
+    content: '';
+    position: absolute;
+    left: 0;
+    bottom: -0.2rem;
+    width: 100%;
+    height: 2px;
+    background: transparent;
+    transition: background 0.2s ease;
+  }
+
+  .site-nav a:hover::after,
+  .site-nav a:focus-visible::after {
+    background: var(--color-accent);
+  }
+
+  .site-nav__cta {
+    margin-left: 0.5rem;
+  }
+
+  .hero__buttons,
+  .cta__actions {
+    flex-direction: row;
+  }
+
+  .split {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    align-items: center;
+  }
+
+  .split--reverse {
+    direction: rtl;
+    text-align: left;
+  }
+
+  .split--reverse > * {
+    direction: ltr;
+  }
+
+  .experience__item {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    align-items: center;
+  }
+
+  .experience__item--reverse .experience__media {
+    order: -1;
+  }
+
+  .cards {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .footer__grid {
+    gap: 2.5rem;
+  }
+}
+
+@media (min-width: 1024px) {
+  .site-header {
+    padding: 1.1rem 2rem;
+  }
+
+  .section {
+    padding-inline: 2rem;
+  }
+
+  .hero {
+    padding-inline: 2rem;
+  }
+
+  .hero__content {
+    gap: 1.75rem;
+  }
+
+  .experience__item,
+  .card,
+  .section--cta .cta {
+    padding: clamp(2.25rem, 3vw, 3rem);
+  }
+}
+
+@media (min-width: 1200px) {
+  .hero__inner {
+    align-items: flex-start;
+  }
+
+  .hero__content {
+    max-width: 40rem;
+  }
+
+  .split {
+    gap: 3rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  [data-animate] {
+    opacity: 1;
+    transform: none;
+    animation: none;
+  }
+
+  .button,
+  .site-nav,
+  .site-header__toggle-line {
+    transition: none;
+  }
+}

--- a/styles.css
+++ b/styles.css
@@ -14,6 +14,7 @@
   --radius-lg: 26px;
   --radius-md: 18px;
   --max-width: 1180px;
+  --header-height: 4.75rem;
 }
 
 * {
@@ -60,7 +61,7 @@ button {
 }
 
 main {
-  padding-top: 4.75rem;
+  padding-top: var(--header-height);
 }
 
 .sr-only {
@@ -271,6 +272,7 @@ body.nav-open .site-header__toggle-line:nth-of-type(3) {
   padding: clamp(5.5rem, 14vw, 10rem) 1.25rem clamp(3.75rem, 10vw, 6rem);
   display: flex;
   justify-content: center;
+  min-height: calc(100vh - var(--header-height));
   color: #fffaf2;
   overflow: hidden;
   background: linear-gradient(135deg, rgba(36, 23, 15, 0.85), rgba(36, 23, 15, 0.54)),


### PR DESCRIPTION
## Summary
- introduce a mobile-first navigation with an accessible toggle and smooth-scroll helper that closes the menu on interaction
- simplify the landing content structure to keep the provided copy while trimming redundant CTA strips
- rebuild the styling system around mobile-first breakpoints for balanced spacing, card grids, and hero/CTA treatments using the existing palette

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d1a8707008832199ec33e413ec9216