### PR TITLE
Streamline CTAs and mobile-first layout

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,15 @@
+Custom License for GOOD FINE DINING Landing Page
+
+Copyright (c) 2024 Simone Cascioli. All rights reserved.
+
+Permission is hereby granted to Simone Cascioli and the Good Fine Dining brand ("the Client") to use, reproduce, display, and modify
+this work for business purposes related to the Client.
+
+Any redistribution, sublicensing, sale, or other commercial use by third parties is prohibited without prior written consent from Simone Cascioli.
+
+The original author retains the right to display this work, in whole or in part, for self-promotional purposes, including public portfolios and case studies,
+provided that such display does not imply endorsement by the Client.
+
+THE WORK IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR
+ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE WORK OR THE USE OR OTHER DEALINGS IN THE WORK.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,49 @@
-# good-fine-dining
+# GOOD FINE DINING – Landing Page
+
+Landing page statica ispirata al sito good.simonecascioli.it, sviluppata con HTML5 e CSS3 per massimizzare performance, accessibilità e ottimizzazione SEO.
+
+## Contenuti
+
+Tutti i testi sono forniti dal cliente e riportati integralmente come da specifiche.
+
+## Requisiti
+
+- Qualsiasi browser moderno.
+- (Opzionale) Un server statico locale per testare la pagina.
+
+## Avvio del progetto
+
+1. Clona il repository e posizionati nella cartella del progetto.
+2. Avvia un server statico, ad esempio con [serve](https://www.npmjs.com/package/serve):
+   ```bash
+   npx serve .
+   ```
+   In alternativa, puoi semplicemente aprire `index.html` direttamente nel browser.
+3. Visita l'URL indicato nel terminale (ad esempio `http://localhost:3000`) per visualizzare la landing page.
+
+## Struttura del progetto
+
+```
+.
+├── index.html      # Struttura del markup e metadati SEO
+├── styles.css      # Stili globali e responsive design
+├── LICENSE         # Licenza del progetto
+└── README.md       # Documentazione e istruzioni
+```
+
+## Tecnologie utilizzate
+
+- HTML5 semantico
+- CSS3 moderno (flexbox, grid, tipografia responsive)
+- Google Fonts (Playfair Display, Work Sans)
+
+## Personalizzazione
+
+Gli stili possono essere adattati modificando le variabili CSS definite in `:root`. Le immagini di background possono essere aggiornate intervenendo sulle proprietà `background` delle relative sezioni.
+
+## SEO e Performance
+
+- Markup semantico con intestazioni gerarchiche corrette.
+- Meta description ottimizzata.
+- Fonts caricati in modo ottimizzato con `preconnect`.
+- Layout responsive con attenzione all'accessibilità del contrasto.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,237 @@
+<!DOCTYPE html>
+<html lang="it">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta
+      name="description"
+      content="GOOD FINE DINING - Atmosfera rilassante, ingredienti esclusivi, vasta selezione di vini, ospitalità e passione."
+    />
+    <title>GOOD FINE DINING</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;600;700&family=Work+Sans:wght@300;400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header class="site-header">
+      <div class="site-header__inner">
+        <a class="site-header__brand" href="#top">GOOD FINE DINING</a>
+        <nav class="site-nav" aria-label="Principale">
+          <a href="#cucina">LA NOSTRA CUCINA</a>
+          <a href="#ingredienti">INGREDIENTI SELEZIONATI</a>
+          <a href="#cantina">LA CANTINA</a>
+          <a href="#proposte">LE NOSTRE PROPOSTE</a>
+          <a class="site-nav__cta" href="tel:+390881123456">Prenota ora</a>
+        </nav>
+      </div>
+    </header>
+
+    <main id="top">
+      <section class="hero" data-animate>
+        <div class="hero__overlay" aria-hidden="true"></div>
+        <div class="hero__inner">
+          <div class="hero__content" data-animate style="--delay: 0.05s">
+            <p class="hero__eyebrow">GOOD FINE DINING</p>
+            <h1>
+              Atmosfera rilassante, ingredienti esclusivi, vasta selezione di vini, ospitalità e passione
+            </h1>
+            <div class="hero__buttons">
+              <a class="button button--accent" href="tel:+390881123456">Prenota telefonicamente</a>
+              <a
+                class="button button--surface"
+                href="https://wa.me/390881123456"
+                target="_blank"
+                rel="noreferrer noopener"
+                >Scrivici su WhatsApp</a
+              >
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="section section--intro" id="cucina">
+        <div class="section__inner">
+          <div class="split" data-animate>
+            <div class="split__content">
+              <h2>LA NOSTRA CUCINA</h2>
+              <p>Tradizione ed innovazione si incontrano in ogni piatto, creando momenti di qualità ed autentica convivialità.</p>
+            </div>
+            <figure class="split__media">
+              <img
+                src="https://images.unsplash.com/photo-1504753793650-d4a2b783c15e?auto=format&fit=crop&w=1200&q=80"
+                alt="Chef al lavoro in cucina"
+              />
+            </figure>
+          </div>
+        </div>
+      </section>
+
+      <section class="section section--ingredients" id="ingredienti">
+        <div class="section__inner">
+          <div class="split split--reverse" data-animate style="--delay: 0.08s">
+            <figure class="split__media">
+              <img
+                src="https://images.unsplash.com/photo-1499636136210-6f4ee915583e?auto=format&fit=crop&w=1200&q=80"
+                alt="Ingredienti freschi su un tavolo"
+              />
+            </figure>
+            <div class="split__content">
+              <h2>INGREDIENTI SELEZIONATI</h2>
+              <p>Scegliamo con cura le migliori materie prime ed i prodotti di qualità per ogni piatto.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="section section--experience" id="cantina">
+        <div class="section__inner">
+          <div class="experience">
+            <article class="experience__item" data-animate>
+              <div class="experience__content">
+                <h2>LA CUCINA</h2>
+                <p>Interpretata con grande qualità e creatività.</p>
+              </div>
+              <figure class="experience__media">
+                <img
+                  src="https://images.unsplash.com/photo-1517248135467-4c7edcad34c4?auto=format&fit=crop&w=1200&q=80"
+                  alt="Dettaglio di un piatto gourmet"
+                />
+              </figure>
+            </article>
+            <article class="experience__item experience__item--reverse" data-animate style="--delay: 0.08s">
+              <div class="experience__content">
+                <h2>LA CANTINA</h2>
+                <p>Curata e selezionata per accompagnare al meglio ogni piatto</p>
+              </div>
+              <figure class="experience__media">
+                <img
+                  src="https://images.unsplash.com/photo-1510626176961-4b57d4fbad03?auto=format&fit=crop&w=1200&q=80"
+                  alt="Bottiglie di vino in cantina"
+                />
+              </figure>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section class="section section--proposte" id="proposte">
+        <div class="section__inner">
+          <header class="section__header" data-animate>
+            <h2>LE NOSTRE PROPOSTE</h2>
+            <p>Dalla cena di tutti i giorni alle occasioni speciali, ogni momento ha la sua proposta ideale.</p>
+          </header>
+          <div class="cards">
+            <article class="card" data-animate style="--delay: 0.05s">
+              <h3>MENU À LA CARTE</h3>
+              <p>Possibilità di scegliere tra una selezione di piatti gustosi ed armoniosi.</p>
+            </article>
+            <article class="card" data-animate style="--delay: 0.1s">
+              <h3>MENU DEGUSTAZIONE</h3>
+              <p>Occasione per organizzare un percorso con abbinamenti cibo/vino che rappresenta la nostra filosofia di ristorazione.</p>
+            </article>
+            <article class="card" data-animate style="--delay: 0.15s">
+              <h3>EVENTI PRIVATI</h3>
+              <p>Menù personalizzati per celebrare le occasioni speciali, con menù dedicati alle vostre esigenze</p>
+            </article>
+          </div>
+          <div class="section__actions section__actions--center" data-animate style="--delay: 0.22s">
+            <a class="button button--accent" href="tel:+390881123456">Prenota il tuo tavolo</a>
+          </div>
+        </div>
+      </section>
+
+      <section class="section section--cta" id="contatti">
+        <div class="section__inner">
+          <div class="cta" data-animate>
+            <div class="cta__content">
+              <h2>HAI ESIGENZE PARTICOLARI?</h2>
+              <p>Contattaci per creare un'esperienza su misura per te e i tuoi ospiti. Saremo felici di organizzare il tuo evento perfetto.</p>
+            </div>
+            <div class="cta__note">
+              <p>Vieni a trovarci.</p>
+              <p>Ti aspettiamo per condividere insieme la passione per la buona cucina.</p>
+            </div>
+            <div class="cta__actions">
+              <a class="button button--accent" href="tel:+390881123456">Chiama ora</a>
+              <a class="button button--surface" href="https://wa.me/390881123456" target="_blank" rel="noreferrer noopener"
+                >Scrivici su WhatsApp</a
+              >
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="footer">
+      <div class="footer__inner">
+        <div class="footer__brand" data-animate>
+          <p class="footer__brand-name">GOOD FINE DINING</p>
+        </div>
+        <div class="footer__grid">
+          <div class="footer__group" data-animate style="--delay: 0.05s">
+            <h3>Contatti</h3>
+            <ul>
+              <li><a href="tel:+390881123456">+39 0881 123456</a></li>
+              <li><a href="mailto:info@goodfoggia.it">info@goodfoggia.it</a></li>
+            </ul>
+          </div>
+          <div class="footer__group" data-animate style="--delay: 0.08s">
+            <h3>Indirizzo</h3>
+            <address>
+              Via Example, 123<br />
+              71121 Foggia (FG)
+            </address>
+            <a href="https://www.google.com/maps?q=Via+Example,+123,+71121+Foggia" target="_blank" rel="noreferrer noopener"
+              >Ottieni indicazioni</a
+            >
+          </div>
+          <div class="footer__group" data-animate style="--delay: 0.11s">
+            <h3>Orari di apertura</h3>
+            <ul class="footer__hours">
+              <li><span>Martedì - Giovedì</span><span>19:30 - 00:00</span></li>
+              <li><span>Venerdì - Sabato</span><span>19:30 - 01:00</span></li>
+              <li><span>Domenica</span><span>19:30 - 00:00</span></li>
+              <li><span>Lunedì</span><span>Chiuso</span></li>
+            </ul>
+          </div>
+        </div>
+        <p class="footer__note">© GOOD FINE DINING. Tutti i diritti riservati.</p>
+      </div>
+    </footer>
+    <script>
+      (function () {
+        const header = document.querySelector('.site-header');
+        const headerOffset = header ? header.offsetHeight : 0;
+        const smoothLinks = document.querySelectorAll('a[href^="#"]');
+
+        smoothLinks.forEach((link) => {
+          link.addEventListener('click', (event) => {
+            const hash = link.getAttribute('href');
+            if (!hash || hash === '#' || hash.startsWith('#!')) {
+              return;
+            }
+
+            const target = document.querySelector(hash);
+            if (!target) {
+              return;
+            }
+
+            event.preventDefault();
+
+            const targetPosition =
+              target.getBoundingClientRect().top + window.pageYOffset - Math.max(headerOffset, 0) + 8;
+
+            window.scrollTo({
+              top: targetPosition,
+              behavior: 'smooth',
+            });
+          });
+        });
+      })();
+    </script>
+  </body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,716 @@
+:root {
+  color-scheme: light;
+  --font-display: 'Playfair Display', 'Times New Roman', serif;
+  --font-sans: 'Work Sans', 'Helvetica Neue', Arial, sans-serif;
+  --color-bg: #f6f1ea;
+  --color-text: #24170f;
+  --color-muted: rgba(36, 23, 15, 0.68);
+  --color-accent: #b88a54;
+  --color-accent-soft: rgba(184, 138, 84, 0.2);
+  --color-surface: rgba(255, 255, 255, 0.82);
+  --color-surface-strong: #fffdf8;
+  --max-width: 1180px;
+  --radius-lg: 28px;
+  --radius-md: 20px;
+  --shadow-soft: 0 25px 65px rgba(36, 23, 15, 0.16);
+  --shadow-strong: 0 32px 80px rgba(36, 23, 15, 0.22);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: var(--font-sans);
+  background-color: var(--color-bg);
+  color: var(--color-text);
+  line-height: 1.65;
+  -webkit-font-smoothing: antialiased;
+}
+
+[data-animate] {
+  opacity: 0;
+  transform: translateY(36px);
+  animation: fade-up var(--duration, 900ms) cubic-bezier(0.22, 0.61, 0.36, 1) var(--delay, 0s) forwards;
+}
+
+@keyframes fade-up {
+  from {
+    opacity: 0;
+    transform: translateY(36px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:hover,
+a:focus {
+  text-decoration: none;
+}
+
+img {
+  display: block;
+  max-width: 100%;
+  height: auto;
+  border-radius: var(--radius-md);
+}
+
+main {
+  padding-top: 6.5rem;
+}
+
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  padding: 1rem 1.25rem;
+  display: flex;
+  justify-content: center;
+  background: linear-gradient(180deg, rgba(246, 241, 234, 0.95) 0%, rgba(246, 241, 234, 0.4) 100%);
+  backdrop-filter: blur(12px);
+  border-bottom: 1px solid rgba(36, 23, 15, 0.06);
+}
+
+.site-header__inner {
+  width: min(100%, var(--max-width));
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.75rem;
+}
+
+.site-header__brand {
+  font-family: var(--font-display);
+  font-weight: 600;
+  letter-spacing: 0.32em;
+  font-size: 0.95rem;
+  text-transform: uppercase;
+  color: var(--color-text);
+}
+
+.site-nav {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  width: 100%;
+  gap: 0.65rem 1.25rem;
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.site-nav a {
+  position: relative;
+  padding-bottom: 0.25rem;
+  color: var(--color-muted);
+  transition: color 0.2s ease;
+}
+
+.site-nav a::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  width: 100%;
+  height: 2px;
+  background-color: transparent;
+  transition: background-color 0.2s ease;
+}
+
+.site-nav a:hover,
+.site-nav a:focus {
+  color: var(--color-text);
+}
+
+.site-nav a:hover::after,
+.site-nav a:focus::after {
+  background-color: var(--color-accent);
+}
+
+.site-nav__cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.55rem 1.25rem;
+  border-radius: 999px;
+  background: linear-gradient(120deg, var(--color-accent) 0%, #cba472 100%);
+  color: #fffdf8;
+  box-shadow: var(--shadow-soft);
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+  width: 100%;
+  max-width: 320px;
+  flex: 1 1 100%;
+}
+
+.site-nav__cta:hover,
+.site-nav__cta:focus {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-strong);
+}
+
+.hero {
+  position: relative;
+  padding: clamp(6rem, 12vw, 10rem) 1.5rem clamp(4rem, 9vw, 6rem);
+  display: flex;
+  justify-content: center;
+  color: #fffaf2;
+  overflow: hidden;
+  background: linear-gradient(135deg, rgba(36, 23, 15, 0.78), rgba(36, 23, 15, 0.45)),
+    url('https://images.unsplash.com/photo-1521017432531-fbd92d768814?auto=format&fit=crop&w=1600&q=80') center / cover no-repeat;
+}
+
+.hero::before,
+.hero::after {
+  content: '';
+  position: absolute;
+  border-radius: 999px;
+  filter: blur(0);
+  opacity: 0.35;
+}
+
+.hero::before {
+  width: 420px;
+  height: 420px;
+  background: radial-gradient(circle, rgba(184, 138, 84, 0.35) 0%, rgba(184, 138, 84, 0) 70%);
+  top: -120px;
+  right: -120px;
+}
+
+.hero::after {
+  width: 320px;
+  height: 320px;
+  background: radial-gradient(circle, rgba(246, 241, 234, 0.22) 0%, rgba(246, 241, 234, 0) 70%);
+  bottom: -80px;
+  left: -100px;
+}
+
+.hero__overlay {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(160deg, rgba(36, 23, 15, 0.76), rgba(36, 23, 15, 0.9));
+}
+
+.hero__inner {
+  position: relative;
+  z-index: 1;
+  width: min(100%, 1200px);
+  display: grid;
+  gap: 3rem;
+}
+
+.hero__content {
+  max-width: 720px;
+}
+
+.hero__eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.4em;
+  font-size: 0.85rem;
+  color: rgba(255, 250, 242, 0.7);
+  margin-bottom: 1.5rem;
+}
+
+.hero h1 {
+  margin: 0;
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: clamp(2.8rem, 5.2vw, 4rem);
+  line-height: 1.2;
+}
+
+.hero__buttons {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin-top: 2.5rem;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.85rem 1.9rem;
+  border-radius: 999px;
+  font-size: 0.95rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  font-weight: 500;
+  transition: transform 0.25s ease, box-shadow 0.25s ease, background-color 0.25s ease;
+}
+
+.button--accent {
+  background: linear-gradient(120deg, var(--color-accent) 0%, #cba472 100%);
+  color: #fffdf8;
+  box-shadow: var(--shadow-soft);
+}
+
+.button--accent:hover,
+.button--accent:focus {
+  transform: translateY(-3px);
+  box-shadow: var(--shadow-strong);
+}
+
+.button--light {
+  background: rgba(255, 250, 242, 0.95);
+  color: var(--color-text);
+  box-shadow: var(--shadow-soft);
+}
+
+.button--light:hover,
+.button--light:focus {
+  transform: translateY(-3px);
+  box-shadow: var(--shadow-strong);
+}
+
+.button--surface {
+  background: rgba(255, 250, 242, 0.95);
+  border: 1px solid rgba(36, 23, 15, 0.08);
+  color: var(--color-text);
+  box-shadow: var(--shadow-soft);
+}
+
+.button--surface:hover,
+.button--surface:focus {
+  transform: translateY(-3px);
+  box-shadow: var(--shadow-strong);
+}
+
+.button--outline {
+  border: 1px solid rgba(184, 138, 84, 0.45);
+  color: var(--color-accent);
+  background: rgba(255, 255, 255, 0.9);
+}
+
+.button--outline:hover,
+.button--outline:focus {
+  transform: translateY(-3px);
+  border-color: var(--color-accent);
+  color: var(--color-text);
+  box-shadow: var(--shadow-soft);
+}
+
+.section {
+  padding: clamp(4.5rem, 9vw, 6.5rem) 1.5rem;
+  position: relative;
+}
+
+.section::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at top left, rgba(184, 138, 84, 0.08), transparent 60%);
+  opacity: 0.7;
+  pointer-events: none;
+}
+
+.section__inner {
+  position: relative;
+  z-index: 1;
+  margin: 0 auto;
+  width: min(100%, var(--max-width));
+}
+
+.section h2,
+.section h3 {
+  font-family: var(--font-display);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.section p {
+  color: var(--color-muted);
+  font-size: 1.05rem;
+  margin: 0;
+}
+
+.section__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.85rem;
+  margin-top: clamp(2.5rem, 5vw, 3.25rem);
+  justify-content: center;
+}
+
+.section__actions--center {
+  justify-content: center;
+}
+
+.section--intro,
+.section--ingredients,
+.section--experience {
+  background: linear-gradient(145deg, rgba(255, 255, 255, 0.55), rgba(255, 255, 255, 0));
+}
+
+.split {
+  display: grid;
+  gap: clamp(2rem, 4vw, 3.5rem);
+  align-items: center;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.split__content h2 {
+  margin: 0 0 1.25rem;
+  font-size: clamp(1.8rem, 3vw, 2.2rem);
+}
+
+.split__content p {
+  font-size: 1.1rem;
+}
+
+.split__media {
+  position: relative;
+}
+
+.split__media::after {
+  content: '';
+  position: absolute;
+  inset: -12px;
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(184, 138, 84, 0.3);
+  z-index: -1;
+}
+
+.split--reverse {
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.section--ingredients .split__media::after {
+  inset: -16px;
+}
+
+.section--experience .experience {
+  display: grid;
+  gap: clamp(2.5rem, 5vw, 3.5rem);
+}
+
+.experience__item {
+  display: grid;
+  gap: clamp(1.75rem, 4vw, 3rem);
+  align-items: center;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  background: var(--color-surface);
+  padding: clamp(2rem, 4vw, 2.75rem);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-soft);
+  transition: transform 0.45s ease, box-shadow 0.45s ease;
+}
+
+.experience__item--reverse {
+  direction: rtl;
+}
+
+.experience__item--reverse > * {
+  direction: ltr;
+}
+
+.experience__item:hover,
+.experience__item:focus-within {
+  transform: translateY(-6px);
+  box-shadow: var(--shadow-strong);
+}
+
+.experience__content h2 {
+  margin: 0 0 1rem;
+  font-size: clamp(1.9rem, 3.2vw, 2.3rem);
+}
+
+.experience__content p {
+  font-size: 1.05rem;
+}
+
+.experience__media img {
+  border-radius: var(--radius-md);
+  box-shadow: 0 20px 50px rgba(36, 23, 15, 0.2);
+}
+
+.section--proposte {
+  background: linear-gradient(165deg, rgba(184, 138, 84, 0.16), rgba(255, 255, 255, 0.65));
+}
+
+.section__header {
+  text-align: center;
+  margin-bottom: clamp(3rem, 6vw, 4rem);
+}
+
+.section__header h2 {
+  font-size: clamp(2.1rem, 3.5vw, 2.8rem);
+  margin-bottom: 1rem;
+}
+
+.cards {
+  display: grid;
+  gap: clamp(1.75rem, 4vw, 2.5rem);
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.card {
+  position: relative;
+  padding: clamp(2rem, 4vw, 2.5rem);
+  border-radius: var(--radius-lg);
+  background: var(--color-surface-strong);
+  box-shadow: var(--shadow-soft);
+  overflow: hidden;
+  transition: transform 0.45s ease, box-shadow 0.45s ease;
+}
+
+.card::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at top right, rgba(184, 138, 84, 0.25), transparent 60%);
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+
+.card:hover::before,
+.card:focus-within::before {
+  opacity: 1;
+}
+
+.card:hover,
+.card:focus-within {
+  transform: translateY(-8px);
+  box-shadow: var(--shadow-strong);
+}
+
+.card h3 {
+  margin: 0 0 1rem;
+  font-size: 1.4rem;
+}
+
+.card p {
+  position: relative;
+  z-index: 1;
+}
+
+.section--cta {
+  background: linear-gradient(180deg, #24170f, #1b120d);
+  color: #fffaf2;
+}
+
+.cta {
+  display: grid;
+  gap: 2.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  align-items: center;
+}
+
+.cta__content h2 {
+  margin: 0 0 1.25rem;
+  font-size: clamp(2rem, 3.5vw, 2.6rem);
+}
+
+.cta__content p {
+  color: rgba(255, 250, 242, 0.82);
+}
+
+.cta__note {
+  padding: 2.25rem;
+  border-radius: var(--radius-md);
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.18);
+}
+
+.cta__note p {
+  color: rgba(255, 250, 242, 0.9);
+  margin-bottom: 0.75rem;
+}
+
+.cta__note p:last-child {
+  margin-bottom: 0;
+}
+
+.cta__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.85rem;
+  justify-content: center;
+}
+
+.footer {
+  background: radial-gradient(circle at top, rgba(27, 18, 13, 0.95), #120b07 70%);
+  color: rgba(255, 250, 242, 0.82);
+  padding: clamp(3rem, 6vw, 4rem) 1.5rem;
+}
+
+.footer__inner {
+  margin: 0 auto;
+  width: min(100%, var(--max-width));
+  display: grid;
+  gap: clamp(2.5rem, 5vw, 3.5rem);
+}
+
+.footer__brand {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.24em;
+}
+
+.footer__brand-name {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: clamp(1.4rem, 3vw, 1.9rem);
+  letter-spacing: 0.32em;
+}
+
+.footer__grid {
+  display: grid;
+  gap: clamp(2rem, 4vw, 3rem);
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.footer__group h3 {
+  margin: 0 0 1rem;
+  font-family: var(--font-display);
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-size: 0.95rem;
+  color: rgba(255, 250, 242, 0.86);
+}
+
+.footer__group ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.65rem;
+}
+
+.footer__group a {
+  color: rgba(255, 250, 242, 0.82);
+  transition: color 0.35s ease;
+}
+
+.footer__group a:hover,
+.footer__group a:focus {
+  color: var(--color-accent);
+}
+
+.footer__group address {
+  font-style: normal;
+  color: rgba(255, 250, 242, 0.82);
+  line-height: 1.8;
+}
+
+.footer__hours {
+  gap: 0.75rem;
+}
+
+.footer__hours li {
+  display: flex;
+  justify-content: space-between;
+  gap: 1.5rem;
+  font-size: 0.95rem;
+}
+
+.footer__hours span:last-child {
+  color: rgba(255, 250, 242, 0.68);
+}
+
+.footer__note {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(255, 250, 242, 0.5);
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+@media (min-width: 720px) {
+  .site-header {
+    padding: 1.25rem 1.75rem;
+  }
+
+  .site-header__inner {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+    gap: 2rem;
+  }
+
+  .site-nav {
+    width: auto;
+    flex-wrap: nowrap;
+    gap: 1.5rem;
+    font-size: 0.95rem;
+  }
+
+  .site-nav__cta {
+    width: auto;
+    max-width: none;
+    flex: 0 0 auto;
+  }
+
+  .hero__buttons {
+    flex-direction: row;
+    flex-wrap: wrap;
+    align-items: center;
+  }
+
+  main {
+    padding-top: 5.5rem;
+  }
+
+  img {
+    border-radius: var(--radius-lg);
+  }
+
+  .split__media::after {
+    inset: -18px;
+  }
+
+  .section--ingredients .split__media::after {
+    inset: -24px;
+  }
+
+  .section__actions {
+    justify-content: flex-start;
+  }
+
+  .section__actions--center {
+    justify-content: center;
+  }
+
+  .cta__actions {
+    justify-content: flex-start;
+  }
+}
+
+@media (min-width: 960px) {
+  .site-nav {
+    gap: 2rem;
+  }
+}
+
+@media (min-width: 1024px) {
+  .hero {
+    background-attachment: fixed;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  [data-animate] {
+    animation: none !important;
+    opacity: 1 !important;
+    transform: none !important;
+  }
+
+  .card,
+  .button,
+  .site-nav a,
+  .experience__item,
+  .footer__group a {
+    transition-duration: 0s !important;
+  }
+}


### PR DESCRIPTION
## Summary
- reduce booking CTAs to the essential touchpoints and add a subtle map link in the footer while preserving the provided copy
- rework navigation, hero buttons, and section call-outs for a mobile-first layout that expands smoothly on larger viewports
- tune section and footer styling to center content on phones and restore spacing and shadows on tablets and desktops

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d1a8707008832199ec33e413ec9216