### PR TITLE
Refactor header CTA into inline icon button

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,19 +19,22 @@
   <body>
     <header class="site-header">
       <div class="site-header__inner">
-        <a class="site-header__brand" href="#top">GOOD FINE DINING</a>
-        <button class="site-header__toggle" type="button" aria-expanded="false" aria-controls="site-nav">
-          <span class="sr-only">Apri il menu</span>
-          <span class="site-header__toggle-line" aria-hidden="true"></span>
-          <span class="site-header__toggle-line" aria-hidden="true"></span>
-          <span class="site-header__toggle-line" aria-hidden="true"></span>
-        </button>
-        <nav class="site-nav" id="site-nav" aria-label="Navigazione principale" data-state="closed">
+        <div class="site-header__branding">
+          <a class="site-header__brand" href="#top">GOOD FINE DINING</a>
+          <a class="site-header__cta" href="tel:+393388906835">
+            <span class="sr-only">Prenota ora</span>
+            <svg aria-hidden="true" viewBox="0 0 24 24" focusable="false">
+              <path
+                d="M6.62 10.79a15.05 15.05 0 006.59 6.59l2.2-2.2a1 1 0 011-.24 11.36 11.36 0 003.56.57 1 1 0 011 1v3.57a1 1 0 01-1 1A17.5 17.5 0 012.5 6a1 1 0 011-1H7a1 1 0 011 1 11.36 11.36 0 00.57 3.56 1 1 0 01-.24 1z"
+              />
+            </svg>
+          </a>
+        </div>
+        <nav class="site-nav" id="site-nav" aria-label="Navigazione principale">
           <a href="#cucina">LA NOSTRA CUCINA</a>
           <a href="#ingredienti">INGREDIENTI SELEZIONATI</a>
           <a href="#cantina">LA CANTINA</a>
           <a href="#proposte">LE NOSTRE PROPOSTE</a>
-          <a class="site-nav__cta" href="tel:+393388906835">Prenota ora</a>
         </nav>
       </div>
     </header>
@@ -207,70 +210,8 @@
     <script>
       (function () {
         const header = document.querySelector('.site-header');
-        const nav = document.querySelector('#site-nav');
-        const toggle = document.querySelector('.site-header__toggle');
-        const toggleLabel = toggle?.querySelector('.sr-only');
         const smoothLinks = document.querySelectorAll('a[href^="#"]');
         const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
-
-        const closeNav = () => {
-          if (!nav) return;
-          nav.dataset.state = 'closed';
-          if (toggle) {
-            toggle.setAttribute('aria-expanded', 'false');
-          }
-          if (toggleLabel) {
-            toggleLabel.textContent = 'Apri il menu';
-          }
-          document.body.classList.remove('nav-open');
-        };
-
-        const openNav = () => {
-          if (!nav) return;
-          nav.dataset.state = 'open';
-          if (toggle) {
-            toggle.setAttribute('aria-expanded', 'true');
-          }
-          if (toggleLabel) {
-            toggleLabel.textContent = 'Chiudi il menu';
-          }
-          document.body.classList.add('nav-open');
-        };
-
-        toggle?.addEventListener('click', () => {
-          if (!nav) return;
-          const isOpen = nav.dataset.state === 'open';
-          if (isOpen) {
-            closeNav();
-          } else {
-            openNav();
-          }
-        });
-
-        window.addEventListener('resize', () => {
-          if (window.innerWidth >= 768) {
-            closeNav();
-          }
-        });
-
-        document.addEventListener('click', (event) => {
-          if (!nav || nav.dataset.state !== 'open') return;
-          if (toggle?.contains(event.target) || nav.contains(event.target)) {
-            return;
-          }
-          closeNav();
-        });
-
-        document.addEventListener('keydown', (event) => {
-          if (event.key !== 'Escape') {
-            return;
-          }
-          if (!nav || nav.dataset.state !== 'open') {
-            return;
-          }
-          closeNav();
-          toggle?.focus();
-        });
 
         const scrollToTarget = (target) => {
           const offset = header ? header.offsetHeight : 0;
@@ -321,7 +262,6 @@
             }
 
             event.preventDefault();
-            closeNav();
             scrollToTarget(target);
           });
         });

--- a/styles.css
+++ b/styles.css
@@ -34,10 +34,6 @@ body {
   -webkit-font-smoothing: antialiased;
 }
 
-body.nav-open {
-  overflow: hidden;
-}
-
 img {
   display: block;
   max-width: 100%;
@@ -110,6 +106,12 @@ button {
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: 1.25rem;
+}
+
+.site-header__branding {
+  display: flex;
+  align-items: center;
   gap: 0.75rem;
 }
 
@@ -121,67 +123,17 @@ button {
   text-transform: uppercase;
 }
 
-.site-header__toggle {
-  display: inline-flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: 0.35rem;
-  padding: 0.35rem;
-  border-radius: 999px;
-  width: 2.75rem;
-  height: 2.75rem;
-  background: rgba(36, 23, 15, 0.08);
-  transition: background 0.2s ease;
-}
-
-.site-header__toggle-line {
-  width: 1.4rem;
-  height: 2px;
-  border-radius: 999px;
-  background-color: var(--color-text);
-  transition: transform 0.2s ease, opacity 0.2s ease;
-}
-
-body.nav-open .site-header__toggle-line:nth-of-type(1) {
-  transform: translateY(6px) rotate(45deg);
-}
-
-body.nav-open .site-header__toggle-line:nth-of-type(2) {
-  opacity: 0;
-}
-
-body.nav-open .site-header__toggle-line:nth-of-type(3) {
-  transform: translateY(-6px) rotate(-45deg);
-}
-
 .site-nav {
-  position: absolute;
-  top: calc(100% + 0.75rem);
-  right: 1.25rem;
-  left: 1.25rem;
+  margin-left: auto;
   display: flex;
-  flex-direction: column;
-  gap: 1rem;
-  padding: 1.5rem;
-  border-radius: var(--radius-md);
-  background: var(--color-surface-strong);
-  box-shadow: var(--shadow-soft);
-  transform-origin: top;
-  transform: scale(0.98);
-  opacity: 0;
-  pointer-events: none;
-  transition: opacity 0.25s ease, transform 0.25s ease;
-}
-
-.site-nav[data-state='open'] {
-  opacity: 1;
-  transform: scale(1);
-  pointer-events: auto;
+  align-items: center;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  gap: 0.85rem;
 }
 
 .site-nav a {
-  font-size: 0.85rem;
+  font-size: 0.8rem;
   letter-spacing: 0.1em;
   text-transform: uppercase;
   color: var(--color-muted);
@@ -193,15 +145,29 @@ body.nav-open .site-header__toggle-line:nth-of-type(3) {
   color: var(--color-text);
 }
 
-.site-nav__cta {
+.site-header__cta {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 0.55rem 1.25rem;
+  width: 2.75rem;
+  height: 2.75rem;
   border-radius: 999px;
   background: linear-gradient(120deg, var(--color-accent), var(--color-accent-strong));
   color: #fffdf8;
   box-shadow: var(--shadow-soft);
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+.site-header__cta svg {
+  width: 1.2rem;
+  height: 1.2rem;
+  fill: currentColor;
+}
+
+.site-header__cta:hover,
+.site-header__cta:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-strong);
 }
 
 .button {


### PR DESCRIPTION
## Summary
- replace the hamburger navigation with a persistent phone CTA icon next to the brand
- simplify the header navigation markup and styles for an always-visible layout
- remove JavaScript related to the dropdown toggle, keeping only smooth scrolling

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e7fb16ea0c83219092c634b2142463