### PR TITLE
Replace header CTA with bootstrap telephone icon

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,19 +20,21 @@
     <header class="site-header">
       <div class="site-header__inner">
         <a class="site-header__brand" href="#top">GOOD FINE DINING</a>
-        <button class="site-header__toggle" type="button" aria-expanded="false" aria-controls="site-nav">
-          <span class="sr-only">Apri il menu</span>
-          <span class="site-header__toggle-line" aria-hidden="true"></span>
-          <span class="site-header__toggle-line" aria-hidden="true"></span>
-          <span class="site-header__toggle-line" aria-hidden="true"></span>
-        </button>
-        <nav class="site-nav" id="site-nav" aria-label="Navigazione principale" data-state="closed">
-          <a href="#cucina">LA NOSTRA CUCINA</a>
-          <a href="#ingredienti">INGREDIENTI SELEZIONATI</a>
-          <a href="#cantina">LA CANTINA</a>
-          <a href="#proposte">LE NOSTRE PROPOSTE</a>
-          <a class="site-nav__cta" href="tel:+393388906835">Prenota ora</a>
-        </nav>
+        <a class="site-header__cta" href="tel:+393388906835">
+          <span class="sr-only">Prenota ora</span>
+          <svg
+            class="site-header__cta-icon bi bi-telephone-fill"
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 16 16"
+            fill="currentColor"
+            aria-hidden="true"
+          >
+            <path
+              fill-rule="evenodd"
+              d="M1.885.511a1.745 1.745 0 0 1 2.61.163l1.514 1.887c.329.41.445.957.315 1.466l-.547 2.19a.678.678 0 0 0 .178.643l2.457 2.457a.678.678 0 0 0 .644.178l2.19-.547a1.745 1.745 0 0 1 1.466.315l1.887 1.514c.829.664.905 1.887.163 2.629l-.451.45c-.716.717-1.761 1.02-2.727.684a17.31 17.31 0 0 1-6.571-4.144A17.31 17.31 0 0 1 .752 3.69c-.335-.966-.033-2.011.684-2.727l.45-.451Z"
+            />
+          </svg>
+        </a>
       </div>
     </header>
 
@@ -207,70 +209,8 @@
     <script>
       (function () {
         const header = document.querySelector('.site-header');
-        const nav = document.querySelector('#site-nav');
-        const toggle = document.querySelector('.site-header__toggle');
-        const toggleLabel = toggle?.querySelector('.sr-only');
         const smoothLinks = document.querySelectorAll('a[href^="#"]');
         const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
-
-        const closeNav = () => {
-          if (!nav) return;
-          nav.dataset.state = 'closed';
-          if (toggle) {
-            toggle.setAttribute('aria-expanded', 'false');
-          }
-          if (toggleLabel) {
-            toggleLabel.textContent = 'Apri il menu';
-          }
-          document.body.classList.remove('nav-open');
-        };
-
-        const openNav = () => {
-          if (!nav) return;
-          nav.dataset.state = 'open';
-          if (toggle) {
-            toggle.setAttribute('aria-expanded', 'true');
-          }
-          if (toggleLabel) {
-            toggleLabel.textContent = 'Chiudi il menu';
-          }
-          document.body.classList.add('nav-open');
-        };
-
-        toggle?.addEventListener('click', () => {
-          if (!nav) return;
-          const isOpen = nav.dataset.state === 'open';
-          if (isOpen) {
-            closeNav();
-          } else {
-            openNav();
-          }
-        });
-
-        window.addEventListener('resize', () => {
-          if (window.innerWidth >= 768) {
-            closeNav();
-          }
-        });
-
-        document.addEventListener('click', (event) => {
-          if (!nav || nav.dataset.state !== 'open') return;
-          if (toggle?.contains(event.target) || nav.contains(event.target)) {
-            return;
-          }
-          closeNav();
-        });
-
-        document.addEventListener('keydown', (event) => {
-          if (event.key !== 'Escape') {
-            return;
-          }
-          if (!nav || nav.dataset.state !== 'open') {
-            return;
-          }
-          closeNav();
-          toggle?.focus();
-        });
 
         const scrollToTarget = (target) => {
           const offset = header ? header.offsetHeight : 0;
@@ -321,7 +261,6 @@
             }
 
             event.preventDefault();
-            closeNav();
             scrollToTarget(target);
           });
         });

--- a/styles.css
+++ b/styles.css
@@ -34,10 +34,6 @@ body {
   -webkit-font-smoothing: antialiased;
 }
 
-body.nav-open {
-  overflow: hidden;
-}
-
 img {
   display: block;
   max-width: 100%;
@@ -121,87 +117,29 @@ button {
   text-transform: uppercase;
 }
 
-.site-header__toggle {
-  display: inline-flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: 0.35rem;
-  padding: 0.35rem;
-  border-radius: 999px;
-  width: 2.75rem;
-  height: 2.75rem;
-  background: rgba(36, 23, 15, 0.08);
-  transition: background 0.2s ease;
-}
-
-.site-header__toggle-line {
-  width: 1.4rem;
-  height: 2px;
-  border-radius: 999px;
-  background-color: var(--color-text);
-  transition: transform 0.2s ease, opacity 0.2s ease;
-}
-
-body.nav-open .site-header__toggle-line:nth-of-type(1) {
-  transform: translateY(6px) rotate(45deg);
-}
-
-body.nav-open .site-header__toggle-line:nth-of-type(2) {
-  opacity: 0;
-}
-
-body.nav-open .site-header__toggle-line:nth-of-type(3) {
-  transform: translateY(-6px) rotate(-45deg);
-}
-
-.site-nav {
-  position: absolute;
-  top: calc(100% + 0.75rem);
-  right: 1.25rem;
-  left: 1.25rem;
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-  padding: 1.5rem;
-  border-radius: var(--radius-md);
-  background: var(--color-surface-strong);
-  box-shadow: var(--shadow-soft);
-  transform-origin: top;
-  transform: scale(0.98);
-  opacity: 0;
-  pointer-events: none;
-  transition: opacity 0.25s ease, transform 0.25s ease;
-}
-
-.site-nav[data-state='open'] {
-  opacity: 1;
-  transform: scale(1);
-  pointer-events: auto;
-}
-
-.site-nav a {
-  font-size: 0.85rem;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
-  color: var(--color-muted);
-  transition: color 0.2s ease;
-}
-
-.site-nav a:hover,
-.site-nav a:focus-visible {
-  color: var(--color-text);
-}
-
-.site-nav__cta {
+.site-header__cta {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 0.55rem 1.25rem;
+  width: 2.85rem;
+  height: 2.85rem;
   border-radius: 999px;
   background: linear-gradient(120deg, var(--color-accent), var(--color-accent-strong));
   color: #fffdf8;
   box-shadow: var(--shadow-soft);
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+.site-header__cta:hover,
+.site-header__cta:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-strong);
+}
+
+.site-header__cta-icon {
+  width: 1.35rem;
+  height: 1.35rem;
+  fill: currentColor;
 }
 
 .button {
@@ -325,6 +263,14 @@ body.nav-open .site-header__toggle-line:nth-of-type(3) {
 .split {
   display: grid;
   gap: clamp(1.75rem, 4vw, 2.5rem);
+  padding: clamp(1.75rem, 4vw, 2.5rem);
+  border-radius: var(--radius-lg);
+  background: var(--color-surface-strong);
+  box-shadow: var(--shadow-soft);
+}
+
+.split--reverse {
+  background: linear-gradient(160deg, rgba(255, 255, 255, 0.95), rgba(246, 241, 234, 0.7));
 }
 
 .split__content h2 {
@@ -557,49 +503,6 @@ body.nav-open .site-header__toggle-line:nth-of-type(3) {
     padding-top: 5.5rem;
   }
 
-  .site-header__toggle {
-    display: none;
-  }
-
-  .site-nav {
-    position: static;
-    flex-direction: row;
-    align-items: center;
-    gap: 1.5rem;
-    padding: 0;
-    background: transparent;
-    box-shadow: none;
-    transform: none;
-    opacity: 1;
-    pointer-events: auto;
-  }
-
-  .site-nav a {
-    font-size: 0.9rem;
-    padding-bottom: 0.2rem;
-    position: relative;
-  }
-
-  .site-nav a::after {
-    content: '';
-    position: absolute;
-    left: 0;
-    bottom: -0.2rem;
-    width: 100%;
-    height: 2px;
-    background: transparent;
-    transition: background 0.2s ease;
-  }
-
-  .site-nav a:hover::after,
-  .site-nav a:focus-visible::after {
-    background: var(--color-accent);
-  }
-
-  .site-nav__cta {
-    margin-left: 0.5rem;
-  }
-
   .hero__buttons,
   .cta__actions {
     flex-direction: row;
@@ -608,6 +511,7 @@ body.nav-open .site-header__toggle-line:nth-of-type(3) {
   .split {
     grid-template-columns: repeat(2, minmax(0, 1fr));
     align-items: center;
+    gap: clamp(2rem, 4vw, 3rem);
   }
 
   .split--reverse {
@@ -683,8 +587,7 @@ body.nav-open .site-header__toggle-line:nth-of-type(3) {
   }
 
   .button,
-  .site-nav,
-  .site-header__toggle-line {
+  .site-header__cta {
     transition: none;
   }
 }


### PR DESCRIPTION
## Summary
- swap the header call-to-action SVG for the provided Bootstrap "telephone-fill" icon while keeping existing styling hooks

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e7f7439aac8321a74dd919fac5dfb1